### PR TITLE
fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
           <h2>Getting started</h2>
 
           <h3>Install</h3>
-          <pre><code><span class="comment">$</span> <span class="native">npm install</span> @citation-js/core @citation-js/plugin-doi @citation-js/plugin-doi</code></pre>
+          <pre><code><span class="comment">$</span> <span class="native">npm install</span> @citation-js/core @citation-js/plugin-doi @citation-js/plugin-csl</code></pre>
 
           <h3>Usage</h3>
           <pre><code data-type="js">// Load Citation.js


### PR DESCRIPTION
should be @citation-js/plugin-csl, not @citation-js/plugin-doi